### PR TITLE
CPP port of the Adafruit LED backpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+build

--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -1,0 +1,321 @@
+/***************************************************
+  This is a library for our I2C LED Backpacks
+
+  Designed specifically to work with the Adafruit LED Matrix backpacks
+  ----> http://www.adafruit.com/products/
+  ----> http://www.adafruit.com/products/
+
+  These displays use I2C to communicate, 2 pins are required to
+  interface. There are multiple selectable I2C addresses. For backpacks
+  with 2 Address Select pins: 0x70, 0x71, 0x72 or 0x73. For backpacks
+  with 3 Address Select pins: 0x70 thru 0x77
+
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.
+  MIT license, all text above must be included in any redistribution
+ ****************************************************/
+
+#include "Adafruit_LEDBackpack.h"
+#include <string.h>
+#include <applibs/log.h>
+#include <errno.h>
+
+#ifndef _BV
+#define _BV(bit) (1<<(bit))
+#endif
+
+#ifndef _swap_int16_t
+#define _swap_int16_t(a, b) { int16_t t = a; a = b; b = t; }
+#endif
+
+static const uint8_t numbertable[] = {
+	0x3F, /* 0 */
+	0x06, /* 1 */
+	0x5B, /* 2 */
+	0x4F, /* 3 */
+	0x66, /* 4 */
+	0x6D, /* 5 */
+	0x7D, /* 6 */
+	0x07, /* 7 */
+	0x7F, /* 8 */
+	0x6F, /* 9 */
+	0x77, /* a */
+	0x7C, /* b */
+	0x39, /* C */
+	0x5E, /* d */
+	0x79, /* E */
+	0x71, /* F */
+};
+
+
+void Adafruit_LEDBackpack::setBrightness(uint8_t b) {
+	if (b > 15) b = 15;
+	uint8_t data; 
+	data = HT16K33_CMD_BRIGHTNESS | b;
+	I2CMaster_Write(fd, i2c_addr, &data, sizeof(data));
+}
+
+void Adafruit_LEDBackpack::blinkRate(uint8_t b) {
+	if (b > 3) b = 0; // turn off if not sure
+	uint8_t data = static_cast<uint8_t>(HT16K33_BLINK_CMD | HT16K33_BLINK_DISPLAYON | (b << 1));
+	I2CMaster_Write(fd, i2c_addr, &data, sizeof(data));
+}
+
+Adafruit_LEDBackpack::Adafruit_LEDBackpack(I2C_InterfaceId interface)
+	: interfaceId(interface)
+	, fd(-1)
+	, i2c_addr(0)
+{
+}
+
+void Adafruit_LEDBackpack::begin(uint8_t _addr = 0x70) {
+	fd = I2CMaster_Open(interfaceId);
+	if (fd < 0) {
+		Log_Debug("Could not open I2C Device: %d\n", errno);
+	}
+	
+	i2c_addr = _addr;
+
+	int ret = 0; 
+	ret = I2CMaster_SetBusSpeed(fd, I2C_BUS_SPEED_STANDARD);
+	if (ret < 0) {
+		Log_Debug("Could not set I2C_BUS_SPEED_STANDARD\n");
+	}
+
+	ret = I2CMaster_SetTimeout(fd, 100);
+	if (ret < 0) {
+		Log_Debug("Could not set I2C timeout\n");
+	}
+
+	const uint8_t osc_on = 0x21; 
+	ret = I2CMaster_Write(fd, i2c_addr, &osc_on, sizeof(osc_on));
+	if (ret < 0) {
+		Log_Debug("Could not set Oscillator On\n");
+	}
+
+	blinkRate(HT16K33_BLINK_OFF);
+	setBrightness(15); // max brightness
+}
+
+void Adafruit_LEDBackpack::writeDisplay(void) {
+	I2CMaster_Write(fd, i2c_addr, reinterpret_cast<uint8_t*>(displaybuffer), sizeof(displaybuffer));
+	uint8_t data[17]; 
+	data[0] = 0x00;
+	memcpy(data + 1, displaybuffer, sizeof(displaybuffer));
+	I2CMaster_Write(fd, i2c_addr, data, sizeof(data));
+}
+
+void Adafruit_LEDBackpack::clear(void) {
+	for (uint8_t i = 0; i < 8; i++) {
+		displaybuffer[i] = 0;
+	}
+}
+
+/******************************* 7 SEGMENT OBJECT */
+
+Adafruit_7segment::Adafruit_7segment(I2C_InterfaceId interface) : Adafruit_LEDBackpack(interface)
+{
+	position = 0;
+}
+
+void Adafruit_7segment::print(unsigned long n, int base)
+{
+	if (base == 0) write(static_cast<uint8_t>(n));
+	else printNumber(n, static_cast<uint8_t>(base));
+}
+
+void Adafruit_7segment::print(char c, int base)
+{
+	print((long)c, base);
+}
+
+void Adafruit_7segment::print(unsigned char b, int base)
+{
+	print((unsigned long)b, base);
+}
+
+void Adafruit_7segment::print(int n, int base)
+{
+	print((long)n, base);
+}
+
+void Adafruit_7segment::print(unsigned int n, int base)
+{
+	print((unsigned long)n, base);
+}
+
+void  Adafruit_7segment::println(void) {
+	position = 0;
+}
+
+void  Adafruit_7segment::println(char c, int base)
+{
+	print(c, base);
+	println();
+}
+
+void  Adafruit_7segment::println(unsigned char b, int base)
+{
+	print(b, base);
+	println();
+}
+
+void  Adafruit_7segment::println(int n, int base)
+{
+	print(n, base);
+	println();
+}
+
+void  Adafruit_7segment::println(unsigned int n, int base)
+{
+	print(n, base);
+	println();
+}
+
+void  Adafruit_7segment::println(long n, int base)
+{
+	print(n, base);
+	println();
+}
+
+void  Adafruit_7segment::println(unsigned long n, int base)
+{
+	print(n, base);
+	println();
+}
+
+void  Adafruit_7segment::println(double n, int digits)
+{
+	print(n, digits);
+	println();
+}
+
+void  Adafruit_7segment::print(double n, int digits)
+{
+	printFloat(n, static_cast<uint8_t>(digits));
+}
+
+
+size_t Adafruit_7segment::write(uint8_t c) {
+
+	uint8_t r = 0;
+
+	if (c == '\n') position = 0;
+	if (c == '\r') position = 0;
+
+	if ((c >= '0') && (c <= '9')) {
+		writeDigitNum(position, static_cast<uint8_t>(c - '0'));
+		r = 1;
+	}
+
+	position++;
+	if (position == 2) position++;
+
+	return r;
+}
+
+void Adafruit_7segment::writeDigitRaw(uint8_t d, uint8_t bitmask) {
+	if (d > 4) return;
+	displaybuffer[d] = bitmask;
+}
+
+void Adafruit_7segment::drawColon(bool state) {
+	if (state)
+		displaybuffer[2] = 0x2;
+	else
+		displaybuffer[2] = 0;
+}
+
+void Adafruit_7segment::writeColon(void) {
+	uint8_t data[3];
+	data[0] = 0x04; // start at address $02
+	memcpy(data + 1, displaybuffer + 2, 2); 
+	I2CMaster_Write(fd, i2c_addr, data, sizeof(data));
+}
+
+void Adafruit_7segment::writeDigitNum(uint8_t d, uint8_t num, bool dot) {
+	if (d > 4) return;
+
+	writeDigitRaw(d, static_cast<uint8_t>(numbertable[num] | (dot << 7)));
+}
+
+void Adafruit_7segment::print(long n, int base)
+{
+	printNumber(n, static_cast<uint8_t>(base));
+}
+
+void Adafruit_7segment::printNumber(long n, uint8_t base)
+{
+	printFloat(n, 0, base);
+}
+
+void Adafruit_7segment::printFloat(double n, uint8_t fracDigits, uint8_t base)
+{
+	uint8_t numericDigits = 4;   // available digits on display
+	bool isNegative = false;  // true if the number is negative
+
+	// is the number negative?
+	if (n < 0) {
+		isNegative = true;  // need to draw sign later
+		--numericDigits;    // the sign will take up one digit
+		n *= -1;            // pretend the number is positive
+	}
+
+	// calculate the factor required to shift all fractional digits
+	// into the integer part of the number
+	double toIntFactor = 1.0;
+	for (int i = 0; i < fracDigits; ++i) toIntFactor *= base;
+
+	// create integer containing digits to display by applying
+	// shifting factor and rounding adjustment
+	uint32_t displayNumber = static_cast<uint32_t>(n * toIntFactor + 0.5);
+
+	// calculate upper bound on displayNumber given
+	// available digits on display
+	uint32_t tooBig = 1;
+	for (int i = 0; i < numericDigits; ++i) tooBig *= base;
+
+	// if displayNumber is too large, try fewer fractional digits
+	while (displayNumber >= tooBig) {
+		--fracDigits;
+		toIntFactor /= base;
+		displayNumber = static_cast<uint32_t>(n * toIntFactor + 0.5);
+	}
+
+	// did toIntFactor shift the decimal off the display?
+	if (toIntFactor < 1) {
+		printError();
+	}
+	else {
+		// otherwise, display the number
+		int8_t displayPos = 4;
+
+		if (displayNumber)  //if displayNumber is not 0
+		{
+			for (uint8_t i = 0; displayNumber || i <= fracDigits; ++i) {
+				bool displayDecimal = (fracDigits != 0 && i == fracDigits);
+				writeDigitNum(displayPos--, static_cast<uint8_t>(displayNumber % base), displayDecimal);
+				if (displayPos == 2) writeDigitRaw(displayPos--, 0x00);
+				displayNumber /= base;
+			}
+		}
+		else {
+			writeDigitNum(displayPos--, 0, false);
+		}
+
+		// display negative sign if negative
+		if (isNegative) writeDigitRaw(displayPos--, 0x40);
+
+		// clear remaining display positions
+		while (displayPos >= 0) writeDigitRaw(displayPos--, 0x00);
+	}
+}
+
+void Adafruit_7segment::printError(void) {
+	for (uint8_t i = 0; i < SEVENSEG_DIGITS; ++i) {
+		writeDigitRaw(i, (i == 2 ? 0x00 : 0x40));
+	}
+}

--- a/Adafruit_LEDBackpack.h
+++ b/Adafruit_LEDBackpack.h
@@ -1,0 +1,101 @@
+/***************************************************
+  This is a library for our I2C LED Backpacks
+
+  Designed specifically to work with the Adafruit LED Matrix backpacks
+  ----> http://www.adafruit.com/products/
+  ----> http://www.adafruit.com/products/
+
+  These displays use I2C to communicate, 2 pins are required to
+  interface. There are multiple selectable I2C addresses. For backpacks
+  with 2 Address Select pins: 0x70, 0x71, 0x72 or 0x73. For backpacks
+  with 3 Address Select pins: 0x70 thru 0x77
+
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.
+  MIT license, all text above must be included in any redistribution
+ ****************************************************/
+#pragma once
+#ifndef Adafruit_LEDBackpack_h
+#define Adafruit_LEDBackpack_h
+
+#include <applibs/i2c.h>
+
+#define LED_ON 1
+#define LED_OFF 0
+
+#define LED_RED 1
+#define LED_YELLOW 2
+#define LED_GREEN 3
+
+#define HT16K33_BLINK_CMD 0x80
+#define HT16K33_BLINK_DISPLAYON 0x01
+#define HT16K33_BLINK_OFF 0
+#define HT16K33_BLINK_2HZ  1
+#define HT16K33_BLINK_1HZ  2
+#define HT16K33_BLINK_HALFHZ  3
+
+#define HT16K33_CMD_BRIGHTNESS 0xE0
+
+#define SEVENSEG_DIGITS 5
+
+
+// base
+#define BYTE 2
+#define DEC 10
+
+ // this is the raw HT16K33 controller
+class Adafruit_LEDBackpack {
+public:
+	Adafruit_LEDBackpack(I2C_InterfaceId interface);
+	void begin(uint8_t _addr);
+	void setBrightness(uint8_t b);
+	void blinkRate(uint8_t b);
+	void writeDisplay(void);
+	void clear(void);
+
+	uint16_t displaybuffer[8];
+
+	void init(uint8_t a);
+protected:
+	I2C_InterfaceId interfaceId;
+	int fd;
+	uint8_t i2c_addr;
+};
+
+class Adafruit_7segment : public Adafruit_LEDBackpack {
+public:
+	Adafruit_7segment(I2C_InterfaceId interface);
+	size_t write(uint8_t c);
+
+	void print(char, int = BYTE);
+	void print(unsigned char, int = BYTE);
+	void print(int, int = DEC);
+	void print(unsigned int, int = DEC);
+	void print(long, int = DEC);
+	void print(unsigned long, int = DEC);
+	void print(double, int = 2);
+	void println(char, int = BYTE);
+	void println(unsigned char, int = BYTE);
+	void println(int, int = DEC);
+	void println(unsigned int, int = DEC);
+	void println(long, int = DEC);
+	void println(unsigned long, int = DEC);
+	void println(double, int = 2);
+	void println(void);
+
+	void writeDigitRaw(uint8_t x, uint8_t bitmask);
+	void writeDigitNum(uint8_t x, uint8_t num, bool dot = false);
+	void drawColon(bool state);
+	void printNumber(long, uint8_t = 2);
+	void printFloat(double, uint8_t = 2, uint8_t = DEC);
+	void printError(void);
+
+	void writeColon(void);
+
+private:
+	uint8_t position;
+};
+#endif // Adafruit_LEDBackpack_h

--- a/examples/7_segment_blink/CMakeLists.txt
+++ b/examples/7_segment_blink/CMakeLists.txt
@@ -1,0 +1,22 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License.
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.11)
+PROJECT(7_Segment_Blink C)
+
+# Create executable
+ADD_EXECUTABLE(
+	${PROJECT_NAME} 
+	main.cpp
+	../../Adafruit_LEDBackpack.cpp
+	../../Adafruit_LEDBackpack.h
+)
+
+#set_target_properties(7_Segment_Blink PROPERTIES CXX_STANDARD 17)
+set_target_properties(7_Segment_Blink PROPERTIES LINKER_LANGUAGE C)
+
+
+TARGET_LINK_LIBRARIES(${PROJECT_NAME} applibs pthread gcc_s c)
+
+# Add MakeImage post-build command
+INCLUDE("${AZURE_SPHERE_MAKE_IMAGE_FILE}")

--- a/examples/7_segment_blink/CMakeLists.txt
+++ b/examples/7_segment_blink/CMakeLists.txt
@@ -2,7 +2,7 @@
 #  Licensed under the MIT License.
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.11)
-PROJECT(7_Segment_Blink C)
+PROJECT(7_Segment_Blink)
 
 # Create executable
 ADD_EXECUTABLE(

--- a/examples/7_segment_blink/Toolchain.cmake
+++ b/examples/7_segment_blink/Toolchain.cmake
@@ -32,7 +32,7 @@ SET(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES "${AZURE_SPHERE_API_SET_DIR}/usr/incl
 ADD_DEFINITIONS(-D_POSIX_C_SOURCE)
 SET(COMPILE_DEBUG_FLAGS $<$<CONFIG:Debug>:-ggdb> $<$<CONFIG:Debug>:-O0>)
 SET(COMPILE_RELEASE_FLAGS $<$<CONFIG:Release>:-g1> $<$<CONFIG:Release>:-Os>)
-ADD_COMPILE_OPTIONS($<$<COMPILE_LANGUAGE:CXX>:-std=c++11> $<$<COMPILE_LANGUAGE:C>:-std=c11>
+ADD_COMPILE_OPTIONS($<$<COMPILE_LANGUAGE:CXX>:-std=c++17> $<$<COMPILE_LANGUAGE:C>:-std=c11>
                      ${COMPILE_DEBUG_FLAGS} ${COMPILE_RELEASE_FLAGS} -fPIC
                     -ffunction-sections -fdata-sections -fno-strict-aliasing
                     -fno-omit-frame-pointer -fno-exceptions -Wall $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>

--- a/examples/7_segment_blink/Toolchain.cmake
+++ b/examples/7_segment_blink/Toolchain.cmake
@@ -1,0 +1,38 @@
+SET(CMAKE_SYSTEM_NAME Generic)
+SET(AZURE_SPHERE_SDK_PATH "C:/Program Files (x86)/Microsoft Azure Sphere SDK" CACHE INTERNAL "Path to the Azure Sphere SDK")
+SET(AZURE_SPHERE_API_SET "3")
+SET(AZURE_SPHERE_CMAKE_PATH "${AZURE_SPHERE_SDK_PATH}/CMakeFiles")
+
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+SET(AZURE_SPHERE_MAKE_IMAGE_FILE "${AZURE_SPHERE_CMAKE_PATH}/AzureSphereMakeImage.cmake" CACHE INTERNAL "Path to the MakeImage CMake target")
+
+# Disable linking during try_compile since our link options cause the generation to fail
+SET(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY CACHE INTERNAL "Disable linking for try_compile")
+
+SET(AZURE_SPHERE_API_SET_DIR "${AZURE_SPHERE_SDK_PATH}/Sysroots/${AZURE_SPHERE_TARGET_API_SET}" CACHE INTERNAL "Path to the selected API set in the Azure Sphere SDK")
+SET(ENV{PATH} "${AZURE_SPHERE_SDK_PATH}/Tools;${AZURE_SPHERE_API_SET_DIR}/tools/gcc;$ENV{PATH}")
+SET(CMAKE_FIND_ROOT_PATH "${AZURE_SPHERE_API_SET_DIR}")
+
+SET(CMAKE_C_COMPILER "${AZURE_SPHERE_API_SET_DIR}/tools/gcc/arm-poky-linux-musleabi-gcc.exe" CACHE INTERNAL "Path to the C compiler in the selected API set targeting High-Level core")
+SET(CMAKE_CXX_COMPILER "${AZURE_SPHERE_API_SET_DIR}/tools/gcc/arm-poky-linux-musleabi-gcc.exe" CACHE INTERNAL "Path to the C compiler in the selected API set targeting High-Level core")
+
+SET(CMAKE_C_FLAGS_INIT "-B \"${AZURE_SPHERE_API_SET_DIR}/tools/gcc\" -march=armv7ve -mthumb -mfpu=neon -mfloat-abi=hard \
+-mcpu=cortex-a7 --sysroot=\"${AZURE_SPHERE_API_SET_DIR}\"")
+SET(CMAKE_EXE_LINKER_FLAGS_INIT "-nodefaultlibs -pie -Wl,--no-undefined -Wl,--gc-sections")
+
+SET(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES "${AZURE_SPHERE_API_SET_DIR}/usr/include")
+
+ADD_DEFINITIONS(-D_POSIX_C_SOURCE)
+SET(COMPILE_DEBUG_FLAGS $<$<CONFIG:Debug>:-ggdb> $<$<CONFIG:Debug>:-O0>)
+SET(COMPILE_RELEASE_FLAGS $<$<CONFIG:Release>:-g1> $<$<CONFIG:Release>:-Os>)
+ADD_COMPILE_OPTIONS(-std=c11 ${COMPILE_DEBUG_FLAGS} ${COMPILE_RELEASE_FLAGS} -fPIC
+                    -ffunction-sections -fdata-sections -fno-strict-aliasing
+                    -fno-omit-frame-pointer -fno-exceptions -Wall -Wstrict-prototypes
+                    -Wswitch -Wempty-body -Wconversion -Wreturn-type -Wparentheses
+                    -Wno-pointer-sign -Wno-format -Wuninitialized -Wunreachable-code
+                    -Wunused-function -Wunused-value -Wunused-variable
+                    -Werror=implicit-function-declaration -fstack-protector-strong)
+

--- a/examples/7_segment_blink/Toolchain.cmake
+++ b/examples/7_segment_blink/Toolchain.cmake
@@ -21,18 +21,23 @@ SET(CMAKE_CXX_COMPILER "${AZURE_SPHERE_API_SET_DIR}/tools/gcc/arm-poky-linux-mus
 
 SET(CMAKE_C_FLAGS_INIT "-B \"${AZURE_SPHERE_API_SET_DIR}/tools/gcc\" -march=armv7ve -mthumb -mfpu=neon -mfloat-abi=hard \
 -mcpu=cortex-a7 --sysroot=\"${AZURE_SPHERE_API_SET_DIR}\"")
+SET(CMAKE_CXX_FLAGS_INIT "-B \"${AZURE_SPHERE_API_SET_DIR}/tools/gcc\" -march=armv7ve -mthumb -mfpu=neon -mfloat-abi=hard \
+-mcpu=cortex-a7 --sysroot=\"${AZURE_SPHERE_API_SET_DIR}\"")
+
 SET(CMAKE_EXE_LINKER_FLAGS_INIT "-nodefaultlibs -pie -Wl,--no-undefined -Wl,--gc-sections")
 
 SET(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES "${AZURE_SPHERE_API_SET_DIR}/usr/include")
+SET(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES "${AZURE_SPHERE_API_SET_DIR}/usr/include")
 
 ADD_DEFINITIONS(-D_POSIX_C_SOURCE)
 SET(COMPILE_DEBUG_FLAGS $<$<CONFIG:Debug>:-ggdb> $<$<CONFIG:Debug>:-O0>)
 SET(COMPILE_RELEASE_FLAGS $<$<CONFIG:Release>:-g1> $<$<CONFIG:Release>:-Os>)
-ADD_COMPILE_OPTIONS(-std=c11 ${COMPILE_DEBUG_FLAGS} ${COMPILE_RELEASE_FLAGS} -fPIC
+ADD_COMPILE_OPTIONS($<$<COMPILE_LANGUAGE:CXX>:-std=c++11> $<$<COMPILE_LANGUAGE:C>:-std=c11>
+                     ${COMPILE_DEBUG_FLAGS} ${COMPILE_RELEASE_FLAGS} -fPIC
                     -ffunction-sections -fdata-sections -fno-strict-aliasing
-                    -fno-omit-frame-pointer -fno-exceptions -Wall -Wstrict-prototypes
+                    -fno-omit-frame-pointer -fno-exceptions -Wall $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>
                     -Wswitch -Wempty-body -Wconversion -Wreturn-type -Wparentheses
-                    -Wno-pointer-sign -Wno-format -Wuninitialized -Wunreachable-code
+                    $<$<COMPILE_LANGUAGE:C>:-Wno-pointer-sign> -Wno-format -Wuninitialized -Wunreachable-code
                     -Wunused-function -Wunused-value -Wunused-variable
                     -Werror=implicit-function-declaration -fstack-protector-strong)
 

--- a/examples/7_segment_blink/app_manifest.json
+++ b/examples/7_segment_blink/app_manifest.json
@@ -1,0 +1,11 @@
+{
+    "SchemaVersion": 1,
+    "Name": "7_segment_blink",
+    "ComponentId": "4886ce44-d136-4cb3-ab10-df998e313914",
+    "EntryPoint": "/bin/app",
+    "CmdArgs": [],
+    "Capabilities": {
+        "I2cMaster": [ "ISU0" ]
+      },
+    "ApplicationType": "Default"
+  }

--- a/examples/7_segment_blink/main.cpp
+++ b/examples/7_segment_blink/main.cpp
@@ -19,25 +19,25 @@ int main(void)
 {
     Log_Debug("Starting 7-Segment Blink application...\n");
 	
-    Adafruit_7segment sevseg; 
+    Adafruit_7segment sevseg(0); 
 
     const struct timespec sleepTime = {1, 0};
-	init_Adafruit_7segment(&sevseg, 0, 0x70);
-	open_Adafruit_7segment(&sevseg); 
+	sevseg.begin(0x70);
 
     while (true) {
 		//print_long_Adafruit_7segment(&sevseg, 8888, 10);
-		writeDigitNum_Adafruit_7segment(&sevseg, 0, 8, true);
-		writeDigitNum_Adafruit_7segment(&sevseg, 1, 8, true);
-		drawColon_Adafruit_7segment(&sevseg, true);
-		writeDigitNum_Adafruit_7segment(&sevseg, 3, 8, true);
-		writeDigitNum_Adafruit_7segment(&sevseg, 4, 8, true);
-		
-		writeDisplay_Adafruit_LEDBackpack(&sevseg.backpack);
+		sevseg.writeDigitNum(0, 8, true);
+		sevseg.writeDigitNum(1, 8, true);
+		sevseg.drawColon(true);
+		sevseg.writeDigitNum(3, 8, true);
+		sevseg.writeDigitNum(4, 8, true);
+		sevseg.writeDisplay(); 
+
 		nanosleep(&sleepTime, NULL);
 
-		clear_Adafruit_LEDBackpack(&sevseg.backpack);
-		writeDisplay_Adafruit_LEDBackpack(&sevseg.backpack);
+		sevseg.clear();
+		sevseg.writeDisplay(); 
+		
 		nanosleep(&sleepTime, NULL);
     }
 

--- a/examples/7_segment_blink/main.cpp
+++ b/examples/7_segment_blink/main.cpp
@@ -1,0 +1,45 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved.
+   Licensed under the MIT License. */
+
+// This minimal Azure Sphere app repeatedly toggles GPIO 8, which is the red channel of RGB
+// LED 1 on the MT3620 RDB. Use this app to test that device and SDK installation succeeded
+// that you can build, deploy, and debug a CMake app with Visual Studio.
+//
+// It uses the API for the following Azure Sphere application libraries:
+// - log (messages shown in Visual Studio's Device Output window during debugging)
+
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+#include <applibs/log.h>
+
+#include "../../Adafruit_LEDBackpack.h"
+
+int main(void)
+{
+    Log_Debug("Starting 7-Segment Blink application...\n");
+	
+    Adafruit_7segment sevseg; 
+
+    const struct timespec sleepTime = {1, 0};
+	init_Adafruit_7segment(&sevseg, 0, 0x70);
+	open_Adafruit_7segment(&sevseg); 
+
+    while (true) {
+		//print_long_Adafruit_7segment(&sevseg, 8888, 10);
+		writeDigitNum_Adafruit_7segment(&sevseg, 0, 8, true);
+		writeDigitNum_Adafruit_7segment(&sevseg, 1, 8, true);
+		drawColon_Adafruit_7segment(&sevseg, true);
+		writeDigitNum_Adafruit_7segment(&sevseg, 3, 8, true);
+		writeDigitNum_Adafruit_7segment(&sevseg, 4, 8, true);
+		
+		writeDisplay_Adafruit_LEDBackpack(&sevseg.backpack);
+		nanosleep(&sleepTime, NULL);
+
+		clear_Adafruit_LEDBackpack(&sevseg.backpack);
+		writeDisplay_Adafruit_LEDBackpack(&sevseg.backpack);
+		nanosleep(&sleepTime, NULL);
+    }
+
+    return 0;
+}

--- a/examples/7_segment_blink/run_cmake.bat
+++ b/examples/7_segment_blink/run_cmake.bat
@@ -2,7 +2,8 @@
 mkdir build
 cd build
 
-cmake.exe -G "Ninja" ^
+cmake ^
+-G "Ninja" ^
 -DCMAKE_INSTALL_PREFIX:PATH="." ^
 -DCMAKE_TOOLCHAIN_FILE="Toolchain.cmake" ^
 -DAZURE_SPHERE_TARGET_API_SET="3" ^

--- a/examples/7_segment_blink/run_cmake.bat
+++ b/examples/7_segment_blink/run_cmake.bat
@@ -1,0 +1,12 @@
+@echo on
+mkdir build
+cd build
+
+cmake.exe -G "Ninja" ^
+-DCMAKE_INSTALL_PREFIX:PATH="." ^
+-DCMAKE_TOOLCHAIN_FILE="Toolchain.cmake" ^
+-DAZURE_SPHERE_TARGET_API_SET="3" ^
+--no-warn-unused-cli ^
+-DCMAKE_BUILD_TYPE="Debug" ^
+-DCMAKE_MAKE_PROGRAM="ninja.exe" ^
+..


### PR DESCRIPTION
This is a CPP port of the Adafruit LED backpack.  The real innovation here is simplifying the CMake so that it compiles without all of the board-independent stuff and so that CPP will compile, the same way it used to do in Visual Stuidio 2019

.cpp IS NOT supported by Microsoft on Azure Sphere.  It worked in VS by accident and now I've duplicated it here. But it IS NOT SUPPORTED!!!  Use at your own risk!